### PR TITLE
Allow dashes in usernames

### DIFF
--- a/bin/github-keygen
+++ b/bin/github-keygen
@@ -98,7 +98,7 @@ my %github_remove;
 
 while (@ARGV) {
     my $user = shift @ARGV;
-    pod2usage("invalid user '$user'") unless $user =~ /^[a-z0-9_]+$/;
+    pod2usage("invalid user '$user'") unless $user =~ /^[a-z0-9_-]+$/;
 
     my $remove = 0;
     my %u = (


### PR DESCRIPTION
Dashes are valid characters in usernames.

Tested end-to-end, everything works.
