### PR TITLE
Ensure correct permissions for ~/.ssh/config

### DIFF
--- a/github-keygen
+++ b/github-keygen
@@ -9806,6 +9806,8 @@ if (@ssh_config_lines) {
         print "Done.\n";
     } else {
     }
+    # ensure correct permissions
+    chmod 0600, SSH_CONFIG_FILE;
 } else {
     if (-e SSH_CONFIG_FILE) {
         printf "Removing %s...\n", compress_path(SSH_CONFIG_FILE);


### PR DESCRIPTION
This patch automates setting the correct file permissions of the ssh client configuration file, which might otherwise be too permissive, should it already exist.