### PR TITLE
Ensure correct permissions for ~/.ssh/config

### DIFF
--- a/bin/github-keygen
+++ b/bin/github-keygen
@@ -735,6 +735,8 @@ if (@ssh_config_lines) {
         print "Done.\n";
     } else {
     }
+    # ensure correct permissions. done here as pre-existing file might have wrong permissions.
+    chmod 0600, SSH_CONFIG_FILE;
 } else {
     if (-e SSH_CONFIG_FILE) {
         printf "Removing %s...\n", compress_path(SSH_CONFIG_FILE);


### PR DESCRIPTION
This patch automates setting the correct file permissions of the ssh client configuration file, which might otherwise be too permissive, should it already exist.

This bug only occurs when the config file exists, and has incorrect permissions, thus requiring changing them with `chmod`.

This PR replaces the prior #32 which was made to the wrong branch.