### PR TITLE
Update: remove MAC hmac-ripemd160 according to changes of OpenSSH 7.6

### DIFF
--- a/bin/github-keygen
+++ b/bin/github-keygen
@@ -515,7 +515,6 @@ if (@github_accounts) {
         mac => [ qw<
             hmac-sha2-512-etm@openssh.com
             hmac-sha2-256-etm@openssh.com
-            hmac-ripemd160-etm@openssh.com
             umac-128-etm@openssh.com
             hmac-sha2-512
         > ],


### PR DESCRIPTION
OpenSSH 7.6 removed support for the hmac-ripemd160 MAC. Keeping the
item may cause error 'Bad SSH2 Mac spec' when config is used with
OpenSSH 7.6+.

https://www.openssh.com/txt/release-7.6