### PR TITLE
Improve regex for SSH key detection by supporting comments

### DIFF
--- a/github-keygen
+++ b/github-keygen
@@ -10204,7 +10204,7 @@ if (@github_accounts) {
             if (open my $f, '<', $pub_key_file) {
                 chomp(my $line = <$f>);
                 close $f;
-                if ($line =~ m/^\S+ +(\S+) /) {
+                if ($line =~ m/^\S+\s+(\S+)(?:\s+|$)/) {
                     $u->{pubkey} = my $pub_key_b64 = $1;
                     #print "$user pubkey: $pub_key_b64\n";
                     unless ($offline) {


### PR DESCRIPTION
Similar issue, a tool I was using generates keys with a comment and this was breaking the automatic parsing of the `.pub` file.

The old pattern (`^\S+ +(\S+) `) would fail if there wasn’t a literal space after the blob or if you had tabs, or no comment at all. 

This new form handles all of those. I'm not very familiar with Perl so I may be doing something wrong here but it works for me locally