### PR TITLE
Allow IdentityFile to point to a .pub file

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -262,7 +262,15 @@ L<the commit log|https://github.com/dolmen/github-keygen/commits/release>.
 
 =over 4
 
-=item v1.401
+=item UNRELEASED
+
+Improve handling of C<IdentityFile> (either from config or given via C<-i>) to allow
+to point directly to a public key file: this is for the case where the private key is
+not stored on disk with the public key but in a more secure area (e.g. macOS SEP).
+Thanks L<agnosticlines|https://github.com/agnosticlines>
+(L<GitHub #65|https://github.com/dolmen/github-keygen/pull/65>)!
+
+=item L<v1.401|https://github.com/dolmen/github-keygen/compare/v1.400...v1.401>
 
 Update key exchange algorithms:
 
@@ -576,6 +584,8 @@ changes in 1.008.
 
 L<Pedro Figueiredo|https://github.com/pfig>: support for GitHub account with
 dashes (v1.009).
+
+L<agosticlines|https://github.com/agnosticlines>: L<GitHub #65|https://github.com/dolmen/github-keygen/pull/65>.
 
 If you want to contribute, have a look to L<CONTRIBUTING.pod>.
 

--- a/bin/github-keygen
+++ b/bin/github-keygen
@@ -758,7 +758,11 @@ EOF
     push @ghkg_config_lines, "\n" if $ghkg_section_pos <= @sections;
 
     # Inject our section
-    splice @sections, $ghkg_section_pos, 0, [ '', '', @ghkg_config_lines ]
+    if ($ghkg_section_pos > scalar @sections) {
+        push @sections, [ '', '', @ghkg_config_lines ]
+    } else {
+        splice @sections, $ghkg_section_pos, 0, [ '', '', @ghkg_config_lines ]
+    }
 }
 
 

--- a/bin/github-keygen
+++ b/bin/github-keygen
@@ -416,7 +416,8 @@ if (@github_accounts) {
 
     foreach my $user (@github_accounts) {
         my $u = $github_accounts{$user};
-        my $pub_key_file = $u->{key_file} . ".pub";
+        my $pub_key_file = $u->{key_file};
+        $pub_key_file .= '.pub' unless $pub_key_file =~ /\.pub\z/;
         if (-e $pub_key_file) {
             if (open my $f, '-|', qw<ssh-keygen -l -f>, $pub_key_file) {
                 chomp(my $fingerprint = <$f>);
@@ -658,6 +659,9 @@ EOF
                 ($u eq $github_default ? (GITHUB_HOSTS) : ()),
             ) . "\n",
             "IdentitiesOnly yes\n",
+            # Note: IdentityFile may be either a private key or a public key (.pub)
+            # depending on the storage method: when the private key is stored
+            # in a more secure area than that directory, the .pub is directly linked here
             'IdentityFile '. compress_path($github_accounts{$u}->{key_file}) . "\n",
             "\n";
     }
@@ -834,7 +838,9 @@ if (@unregistered_users) {
     if (@clip_cmd && @unregistered_users == 1 && !$offline) {
         my $user = shift @unregistered_users;
         # Copy the first key created to the clipboard
-        my $pub_key_file = $github_accounts{$user}->{key_file}.".pub";
+        my $pub_key_file = $github_accounts{$user}->{key_file};
+        $pub_key_file .= '.pub' unless $pub_key_file =~ /\.pub\z/;
+
         # Read the public key from the file
         open my $pub, '<', $pub_key_file;
         my $pubkey = <$pub>;
@@ -854,11 +860,12 @@ if (@unregistered_users) {
             . "<https://github.com/settings/keys>.\n";
         # Help the user to copy the other keys
         foreach my $user (@unregistered_users) {
-            my $pub_key = compress_path($github_accounts{$user}{key_file}).".pub";
+            my $pub_key_file = compress_path($github_accounts{$user}{key_file});
+            $pub_key_file .= '.pub' unless $pub_key_file =~ /\.pub\z/;
             if (@clip_cmd) {
-                print "  $user:  @clip_cmd < $pub_key\n";
+                print "  $user:  @clip_cmd < $pub_key_file\n";
             } else {
-                print "  $user:  $pub_key\n";
+                print "  $user:  $pub_key_file\n";
             }
         }
         if ($offline) {


### PR DESCRIPTION
Improve handling of `IdentityFile` (also flag `-i`) to allow to point directly to a public key file (.pub). This is for the case where the private key is not stored on disk but in a more secure area.
    
Thanks to @agnosticlines for explaining the use case and providing a first version of the patch in #65.